### PR TITLE
fix!: bug of `verifyMultiRowRootsToDataRootTupleRoot`

### DIFF
--- a/src/lib/verifier/DAVerifier.sol
+++ b/src/lib/verifier/DAVerifier.sol
@@ -163,15 +163,13 @@ library DAVerifier {
     /// @param _bridge The Blobstream smart contract instance.
     /// @param _rowRoot The row/column root to be proven.
     /// @param _rowProof The proof of the row/column root to the data root.
-    /// @param _root The data root of the block that contains the row.
     /// @return `true` if the proof is valid, `false` otherwise.
     /// @return an error code if the proof is invalid, ErrorCodes.NoError otherwise.
     function verifyRowRootToDataRootTupleRoot(
         IDAOracle _bridge,
         NamespaceNode memory _rowRoot,
         BinaryMerkleProof memory _rowProof,
-        AttestationProof memory _attestationProof,
-        bytes32 _root
+        AttestationProof memory _attestationProof
     ) internal view returns (bool, ErrorCodes) {
         // checking that the data root was committed to by the Blobstream smart contract
         if (
@@ -182,7 +180,8 @@ library DAVerifier {
             return (false, ErrorCodes.InvalidDataRootTupleToDataRootTupleRootProof);
         }
 
-        (bool valid, ErrorCodes error) = verifyRowRootToDataRootTupleRootProof(_rowRoot, _rowProof, _root);
+        (bool valid, ErrorCodes error) =
+            verifyRowRootToDataRootTupleRootProof(_rowRoot, _rowProof, _attestationProof.tuple.dataRoot);
 
         return (valid, error);
     }

--- a/src/lib/verifier/DAVerifier.sol
+++ b/src/lib/verifier/DAVerifier.sol
@@ -220,8 +220,7 @@ library DAVerifier {
         IDAOracle _bridge,
         NamespaceNode[] memory _rowRoots,
         BinaryMerkleProof[] memory _rowProofs,
-        AttestationProof memory _attestationProof,
-        bytes32 _root
+        AttestationProof memory _attestationProof
     ) internal view returns (bool, ErrorCodes) {
         // checking that the data root was committed to by the Blobstream smart contract
         if (
@@ -233,7 +232,8 @@ library DAVerifier {
         }
 
         // checking that the rows roots commit to the data root.
-        (bool valid, ErrorCodes error) = verifyMultiRowRootsToDataRootTupleRootProof(_rowRoots, _rowProofs, _root);
+        (bool valid, ErrorCodes error) =
+            verifyMultiRowRootsToDataRootTupleRootProof(_rowRoots, _rowProofs, _attestationProof.tuple.dataRoot);
 
         return (valid, error);
     }

--- a/src/lib/verifier/DAVerifier.sol
+++ b/src/lib/verifier/DAVerifier.sol
@@ -78,17 +78,16 @@ library DAVerifier {
     /// @notice Verifies that the shares, which were posted to Celestia, were committed to by the Blobstream smart contract.
     /// @param _bridge The Blobstream smart contract instance.
     /// @param _sharesProof The proof of the shares to the data root tuple root.
-    /// @param _root The data root of the block that contains the shares.
     /// @return `true` if the proof is valid, `false` otherwise.
     /// @return an error code if the proof is invalid, ErrorCodes.NoError otherwise.
-    function verifySharesToDataRootTupleRoot(IDAOracle _bridge, SharesProof memory _sharesProof, bytes32 _root)
+    function verifySharesToDataRootTupleRoot(IDAOracle _bridge, SharesProof memory _sharesProof)
         internal
         view
         returns (bool, ErrorCodes)
     {
         // checking that the data root was committed to by the Blobstream smart contract.
         (bool success, ErrorCodes errorCode) = verifyMultiRowRootsToDataRootTupleRoot(
-            _bridge, _sharesProof.rowRoots, _sharesProof.rowProofs, _sharesProof.attestationProof, _root
+            _bridge, _sharesProof.rowRoots, _sharesProof.rowProofs, _sharesProof.attestationProof
         );
         if (!success) {
             return (false, errorCode);
@@ -100,7 +99,7 @@ library DAVerifier {
             _sharesProof.namespace,
             _sharesProof.rowRoots,
             _sharesProof.rowProofs,
-            _root
+            _sharesProof.attestationProof.tuple.dataRoot
         );
 
         return (valid, error);
@@ -213,7 +212,6 @@ library DAVerifier {
     /// @param _bridge The Blobstream smart contract instance.
     /// @param _rowRoots The set of row/column roots to be proved.
     /// @param _rowProofs The set of proofs of the _rowRoots in the same order.
-    /// @param _root The data root of the block that contains the rows.
     /// @return `true` if the proof is valid, `false` otherwise.
     /// @return an error code if the proof is invalid, ErrorCodes.NoError otherwise.
     function verifyMultiRowRootsToDataRootTupleRoot(

--- a/src/lib/verifier/test/DAVerifier.t.sol
+++ b/src/lib/verifier/test/DAVerifier.t.sol
@@ -137,11 +137,7 @@ contract DAVerifierTest is DSTest {
         );
 
         (bool valid, DAVerifier.ErrorCodes errorCode) = DAVerifier.verifyRowRootToDataRootTupleRoot(
-            bridge,
-            fixture.getFirstRowRootNode(),
-            fixture.getRowRootToDataRootProof(),
-            attestationProof,
-            fixture.dataRoot()
+            bridge, fixture.getFirstRowRootNode(), fixture.getRowRootToDataRootProof(), attestationProof
         );
         assertTrue(valid);
         assertEq(uint8(errorCode), uint8(DAVerifier.ErrorCodes.NoError));

--- a/src/lib/verifier/test/DAVerifier.t.sol
+++ b/src/lib/verifier/test/DAVerifier.t.sol
@@ -126,8 +126,7 @@ contract DAVerifierTest is DSTest {
         SharesProof memory sharesProof =
             SharesProof(_data, _shareProofs, fixture.getNamespace(), _rowRoots, _rowProofs, attestationProof);
 
-        (bool valid, DAVerifier.ErrorCodes errorCode) =
-            DAVerifier.verifySharesToDataRootTupleRoot(bridge, sharesProof, fixture.dataRoot());
+        (bool valid, DAVerifier.ErrorCodes errorCode) = DAVerifier.verifySharesToDataRootTupleRoot(bridge, sharesProof);
         assertTrue(valid);
         assertEq(uint8(errorCode), uint8(DAVerifier.ErrorCodes.NoError));
     }
@@ -159,9 +158,8 @@ contract DAVerifierTest is DSTest {
             fixture.dataRootTupleRootNonce(), fixture.getDataRootTuple(), fixture.getDataRootTupleProof()
         );
 
-        (bool valid, DAVerifier.ErrorCodes errorCode) = DAVerifier.verifyMultiRowRootsToDataRootTupleRoot(
-            bridge, _rowRoots, _rowProofs, attestationProof, fixture.dataRoot()
-        );
+        (bool valid, DAVerifier.ErrorCodes errorCode) =
+            DAVerifier.verifyMultiRowRootsToDataRootTupleRoot(bridge, _rowRoots, _rowProofs, attestationProof);
         assertTrue(valid);
         assertEq(uint8(errorCode), uint8(DAVerifier.ErrorCodes.NoError));
     }

--- a/src/lib/verifier/test/RollupInclusionProofs.t.sol
+++ b/src/lib/verifier/test/RollupInclusionProofs.t.sol
@@ -323,8 +323,7 @@ contract RollupInclusionProofTest is DSTest {
 
         // let's authenticate the share proof to the data root tuple root to be sure that
         // the square size is valid.
-        (bool success, DAVerifier.ErrorCodes error) =
-            DAVerifier.verifySharesToDataRootTupleRoot(bridge, shareProof, fixture.dataRoot());
+        (bool success, DAVerifier.ErrorCodes error) = DAVerifier.verifySharesToDataRootTupleRoot(bridge, shareProof);
         assertTrue(success);
         assertEq(uint8(error), uint8(DAVerifier.ErrorCodes.NoError));
 

--- a/src/lib/verifier/test/RollupInclusionProofs.t.sol
+++ b/src/lib/verifier/test/RollupInclusionProofs.t.sol
@@ -268,11 +268,7 @@ contract RollupInclusionProofTest is DSTest {
         );
         bool success;
         (success, error) = DAVerifier.verifyRowRootToDataRootTupleRoot(
-            bridge,
-            fixture.getFirstRowRootNode(),
-            fixture.getRowRootToDataRootProof(),
-            attestationProof,
-            fixture.dataRoot()
+            bridge, fixture.getFirstRowRootNode(), fixture.getRowRootToDataRootProof(), attestationProof
         );
         assertTrue(success);
         assertEq(uint8(error), uint8(DAVerifier.ErrorCodes.NoError));


### PR DESCRIPTION
The original `_root` parameter is not verified before being used in `verifyMultiRowRootsToDataRootTupleRootProof`, it will allow arbitrary `_rowRoots` to be proved valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Enhanced data integrity checks by updating the verification process in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->