### PR TITLE
docs: add the definition of the square size to methods

### DIFF
--- a/src/lib/verifier/DAVerifier.sol
+++ b/src/lib/verifier/DAVerifier.sol
@@ -265,6 +265,7 @@ library DAVerifier {
     }
 
     /// @notice computes the Celestia block square size from a row/column root to data root binary merkle proof.
+    /// The square size is the number of rows of the original square.
     /// Note: the provided proof is not authenticated to the Blobstream smart contract. It is the user's responsibility
     /// to verify that the proof is valid and was successfully committed to using
     //  the `DAVerifier.verifyRowRootToDataRootTupleRoot()` method
@@ -286,6 +287,7 @@ library DAVerifier {
     }
 
     /// @notice computes the Celestia block square size from a shares to row/column root proof.
+    /// The square size is the number of rows of the original square.
     /// Note: the provided proof is not authenticated to the Blobstream smart contract. It is the user's responsibility
     /// to verify that the proof is valid and that the shares were successfully committed to using
     /// the `DAVerifier.verifySharesToDataRootTupleRoot()` method.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

To avoid needing to explain what the Celestia block size is, this PR adds that definition to the methods docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added clarifying comments to functions in the verification process, explaining that the square size represents the number of rows of the original square.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->