### PR TITLE
Fix syntax error gen.sh

### DIFF
--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -18,7 +18,7 @@ forge build -C lib/openzeppelin-contracts/contracts/proxy > /dev/null
 
 cd "$1"
 
-for file in "${@: 2}"; do
+for file in "${@:2}"; do
     mkdir -p ../wrappers/"${file}"
     contractName=$(basename "${file}" .sol)
 


### PR DESCRIPTION
**Description:**

This PR addresses a small syntax error in the bash script. The original line:

```bash
for file in "${@: 2}"; do
```

has an unnecessary space after the colon. The corrected line is:

```bash
for file in "${@:2}"; do
```

**Explanation of the fix:**

In bash scripting, the correct syntax for parameter expansion with the `@` symbol is `"{@:2}"` (without the space). The presence of the space could lead to unexpected behavior or errors in some bash environments. This fix ensures that the script will function as intended.

**Why this is important:**

While this issue may not always cause a failure, adhering to the correct syntax ensures compatibility across different bash versions and prevents potential bugs, especially when dealing with positional parameters in loops. This change improves the stability and reliability of the script.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Minor syntax improvement in the script for better adherence to standard practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->