### PR TITLE
fix: typo in DAVerifier.sol file

### DIFF
--- a/src/lib/verifier/DAVerifier.sol
+++ b/src/lib/verifier/DAVerifier.sol
@@ -29,7 +29,7 @@ struct SharesProof {
 }
 
 /// @notice Contains the necessary parameters needed to verify that a data root tuple
-/// was committed to, by the Blobstream smart contract, at some specif nonce.
+/// was committed to, by the Blobstream smart contract, at some specific nonce.
 struct AttestationProof {
     // the attestation nonce that commits to the data root tuple.
     uint256 tupleRootNonce;


### PR DESCRIPTION
Corrected `specif` → `specific`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the comment describing the `AttestationProof` struct for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->