### PR TITLE
fix(typo): correct spelling of 'multiproof' in NamespaceMerkleTree.sol doc comment

### DIFF
--- a/src/lib/tree/namespace/NamespaceMerkleTree.sol
+++ b/src/lib/tree/namespace/NamespaceMerkleTree.sol
@@ -137,7 +137,7 @@ library NamespaceMerkleTree {
         return namespaceNodeEquals(root, node);
     }
 
-    /// @notice Verify if contiguous elements exists in Merkle tree, given leaves, mutliproof, and root.
+    /// @notice Verify if contiguous elements exists in Merkle tree, given leaves, multiproof, and root.
     /// @param root The root of the tree in which the given leaves are verified.
     /// @param proof Namespace Merkle multiproof for the leaves.
     /// @param namespace Namespace of the leaves. All leaves must have the same namespace.


### PR DESCRIPTION
Fixed a typo in the docstring of NamespaceMerkleTree.sol

- Replaced mutliproof → multiproof



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling mistake in the documentation, updating "mutliproof" to "multiproof".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->