### PR TITLE
fix: remove unnecessary case-insensitive flag from import regex in hardhat config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -17,7 +17,7 @@ const config: HardhatUserConfig = {
   preprocess: {
     eachLine: (hre) => ({
       transform: (line: string) => {
-        if (line.match(/^\s*import /i)) {
+        if (line.match(/^\s*import /)) {
           for (const [from, to] of getRemappings()) {
             if (line.includes(from)) {
               line = line.replace(from, to);


### PR DESCRIPTION


## Overview

Remove the 'i' flag from /^\s*import /i regex in hardhat.config.ts. The 'import' keyword in JavaScript/TypeScript is always lowercase, so case-insensitive matching is unnecessary and adds overhead


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Import remapping detection is now case-sensitive. Only lines beginning with optional whitespace and lowercase "import" are remapped; uppercase variants (e.g., "Import") are ignored.
  * Developers using uppercase import statements may see remappings no longer applied and should update to lowercase "import".
  * No changes to compilation settings, paths, or other preprocessing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->