### PR TITLE
chore: Bump Go version from 1.24.0 to 1.26.1

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.0
+          go-version: 1.26.1
 
       - name: Verify Go Mod and Go Sum
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24.0"
+          go-version: "1.26.1"
 
       - name: Install Foundry
         uses: onbjerg/foundry-toolchain@v1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celestiaorg/blobstream-contracts/v4
 
-go 1.24.0
+go 1.26.1
 
 require github.com/ethereum/go-ethereum v1.17.1
 

--- a/scripts/Dockerfile_Environment
+++ b/scripts/Dockerfile_Environment
@@ -28,7 +28,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash && . /root/.bashrc && foundryup
 RUN wget https://github.com/ethereum/solidity/releases/download/v0.8.22/solc-static-linux -O /usr/bin/solc && chmod +x /usr/bin/solc
 
 # install go
-RUN wget https://go.dev/dl/go1.24.0.linux-arm64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.0.linux-arm64.tar.gz && echo 'PATH=$PATH:/usr/local/go/bin:/root/go/bin' >> ~/.bashrc
+RUN wget https://go.dev/dl/go1.26.1.linux-arm64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.1.linux-arm64.tar.gz && echo 'PATH=$PATH:/usr/local/go/bin:/root/go/bin' >> ~/.bashrc
 
 # install abigen
 RUN git clone --depth 1 --branch v1.15.3 https://github.com/ethereum/go-ethereum.git && cd go-ethereum && PATH=$PATH:/usr/local/go/bin make devtools


### PR DESCRIPTION
## Summary
- Bumps the Go directive in `go.mod` from 1.24.0 to 1.26.1 (latest stable release)

## Test plan
- [ ] CI passes with the new Go version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Go toolchain from 1.24.0 to 1.26.1 across the project.
  * Updated CI workflows to use the newer Go version.
  * Updated the environment Docker setup to install Go 1.26.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->