### PR TITLE
chore: add CLAUDE.md with Hacken bug bounty PR guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+## Security PRs
+
+- For PRs that resolve Hacken bug bounty reports, do not include details about the bug in the PR description. Instead, link to a Linear issue that contains more details on the bug and the link to the Hacken bug bounty report.


### PR DESCRIPTION
## Summary
- Add a `CLAUDE.md` file with a "Security PRs" section instructing Claude to not include bug details in PR descriptions for Hacken bug bounty fixes

Closes https://linear.app/celestia/issue/PROTOCO-1445/update-claudemd

## Test plan
- [ ] Verify `CLAUDE.md` is present at the repo root with the Security PRs section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added internal process guidelines for security-related contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->