### PR TITLE
fix: add zero-nonce guard in verifyAttestation

### DIFF
--- a/src/Blobstream.sol
+++ b/src/Blobstream.sol
@@ -355,7 +355,7 @@ contract Blobstream is IDAOracle, Initializable, UUPSUpgradeable, OwnableUpgrade
         returns (bool)
     {
         // Tuple must have been committed before.
-        if (_tupleRootNonce > state_eventNonce) {
+        if (_tupleRootNonce == 0 || _tupleRootNonce > state_eventNonce) {
             return false;
         }
 


### PR DESCRIPTION
 verifyAttestation allowed nonce 0 through, causing state_dataRootTupleRoots[0] to return bytes32(0). An attacker could craft a Merkle proof against that empty root and get a false-positive attestation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced nonce validation to reject zero values, preventing potential misuse of invalid nonce inputs in attestation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->